### PR TITLE
Planar reflections fixes

### DIFF
--- a/Media/2.0/scripts/Compositors/Tutorial_Terrain.compositor
+++ b/Media/2.0/scripts/Compositors/Tutorial_Terrain.compositor
@@ -187,7 +187,8 @@ compositor_node Tutorial_TerrainRenderingNode
 	{
 		pass render_quad
 		{
-			load { all dont_care }
+			// Only colour must be dont_care, since we must still preserve the depth buffer's contents!
+			load { colour dont_care }
 			material Ogre/Copy/4xFP32
 			input 0 rtt01
 		}

--- a/include/OgrePlanarReflections.h
+++ b/include/OgrePlanarReflections.h
@@ -263,7 +263,6 @@ namespace Ogre
             Assumes 'passBufferPtr' is aligned to a vec4/float4 boundary.
         */
         void fillConstBufferData( TextureGpu *renderTarget, const Camera *camera,
-                                  const Matrix4        &projectionMatrix,
                                   float *RESTRICT_ALIAS passBufferPtr ) const;
 
         TextureGpu *getTexture( uint8 actorIdx ) const;

--- a/src/OgrePlanarReflections.cpp
+++ b/src/OgrePlanarReflections.cpp
@@ -883,7 +883,6 @@ namespace Ogre
     }
     //-----------------------------------------------------------------------------------
     void PlanarReflections::fillConstBufferData( TextureGpu *renderTarget, const Camera *camera,
-                                                 const Matrix4 &projectionMatrix,
                                                  float *RESTRICT_ALIAS passBufferPtr ) const
     {
         const Matrix4 viewMatrix = camera->getViewMatrix( true );
@@ -915,7 +914,10 @@ namespace Ogre
         memset( passBufferPtr, 0, ( mMaxActiveActors - mActiveActors.size() ) * 4u * sizeof( float ) );
         passBufferPtr += ( mMaxActiveActors - mActiveActors.size() ) * 4u;
 
-        Matrix4 reflProjMat = PROJECTIONCLIPSPACE2DTOIMAGESPACE_PERSPECTIVE * projectionMatrix;
+        // We call getProjectionMatrixWithRSDepth directly because
+        // it must NOT account for requiresTextureFlipping.
+        Matrix4 reflProjMat =
+            PROJECTIONCLIPSPACE2DTOIMAGESPACE_PERSPECTIVE * camera->getProjectionMatrixWithRSDepth();
         for( size_t i = 0; i < 16; ++i )
             *passBufferPtr++ = (float)reflProjMat[0][i];
 


### PR DESCRIPTION
Thanks for the repro!

The fix was applied to upstream, and this changes your code to account it.

Additionally running it on Vulkan spotted that your load action was wrong for reflections, as the depth buffer contents were being thrown away while they were still needed; resulting in visual corruption when rendering the water plane in Vulkan on some GPUs.